### PR TITLE
Chained removed from ERecTxtD

### DIFF
--- a/Core/access-structs.h
+++ b/Core/access-structs.h
@@ -12,32 +12,6 @@ class FrmlElemSum;
 class FieldDescr;
 class LocVarBlkD;
 
-//struct FieldListEl : public Chained<FieldListEl>
-//{
-//	FieldDescr* FldD = nullptr;
-//};
-//typedef FieldListEl* FieldList;
-// std::vector<FieldDescr*>&
-
-//struct FrmlListEl : public Chained<FrmlListEl>
-//{
-//	FrmlElem* Frml = nullptr;
-//};
-//typedef FrmlListEl* FrmlList;
-// std::vector<FrmlElem*>&
-
-//struct StringListEl : public Chained<StringListEl>
-//{
-//	std::string S;
-//};
-//typedef StringListEl* StringList;
-
-//struct KeyListEl : public Chained<KeyListEl>
-//{
-//	XKey* Key = nullptr;
-//};
-// std::vector<XKey*>
-
 struct KeyInD
 {
 	std::vector<FrmlElem*> FL1;

--- a/Core/rdrun.h
+++ b/Core/rdrun.h
@@ -177,7 +177,7 @@ struct EFldD
 	bool Ed(bool IsNewRec);
 };
 
-struct ERecTxtD : public Chained<ERecTxtD>
+struct ERecTxtD
 {
 	WORD N;
 	std::vector<std::string> SL;

--- a/Core/wwmenu.cpp
+++ b/Core/wwmenu.cpp
@@ -611,6 +611,7 @@ bool TMenuBoxP::ExecItem(WORD& I)
 {
 	bool result = false;
 	if (!PD->PullDown) return result;
+
 	if (I == 0) {
 		if ((Event.What == evMouseDown) || !PD->WasESCBranch) return result;
 		RunInstr(PD->ESCInstr);
@@ -619,8 +620,14 @@ bool TMenuBoxP::ExecItem(WORD& I)
 		ChoiceD* choice = getChoice(I);
 		RunInstr(choice->v_instr);
 	}
-	if (ExitP) { I = 255; return result; }
+
+	if (ExitP) {
+		I = 255;
+		return result;
+	}
+
 	I = 0;
+
 	if (PD->Loop) {
 		if (BreakP) {
 			BreakP = false;
@@ -628,11 +635,13 @@ bool TMenuBoxP::ExecItem(WORD& I)
 		}
 		result = true;
 	}
-	else
+	else {
 		if (BreakP) {
 			BreakP = false;
 			I = 255;
 		}
+	}
+
 	return result;
 }
 

--- a/DataEditor/DataEditor.cpp
+++ b/DataEditor/DataEditor.cpp
@@ -1014,9 +1014,10 @@ void DataEditor::NewRecExit()
 void DataEditor::SetCPage(WORD& c_page, ERecTxtD** rt)
 {
 	c_page = (*CFld)->Page;
-	*rt = edit_->RecTxt;
+	*rt = edit_->RecTxt[0];
 	for (WORD i = 1; i < c_page; i++) {
-		*rt = (*rt)->pChain;
+		//*rt = (*rt)->pChain;
+		*rt = edit_->RecTxt[i];
 	}
 }
 

--- a/DataEditor/EditD.h
+++ b/DataEditor/EditD.h
@@ -52,7 +52,7 @@ public:
 	BYTE RecNrPos = 0, RecNrLen = 0;
 	BYTE NPages = 0;
 	//std::vector<std::string> RecTxt;
-	ERecTxtD* RecTxt = nullptr;
+	std::vector<ERecTxtD*> RecTxt;
 	BYTE NRecs = 0;     /*display*/
 	std::vector<EFldD*> FirstFld;
 	std::vector<EFldD*>::iterator CFld;

--- a/DataEditor/EditReader.cpp
+++ b/DataEditor/EditReader.cpp
@@ -46,8 +46,9 @@ void EditReader::StoreRT(WORD Ln, std::vector<std::string>& SL, WORD NFlds)
 	}
 	RT->N = Ln;
 	RT->SL = SL;
-	if (edit_->RecTxt == nullptr) edit_->RecTxt = RT;
-	else ChainLast(edit_->RecTxt, RT);
+	//if (edit_->RecTxt == nullptr) edit_->RecTxt = RT;
+	//else ChainLast(edit_->RecTxt, RT);
+	edit_->RecTxt.push_back(RT);
 }
 
 void EditReader::RdEForm(EditD* edit, RdbPos FormPos)
@@ -331,7 +332,7 @@ void EditReader::AutoDesign(std::vector<FieldDescr*>& FL)
 	edit_->LastFld = edit_->FirstFld.back();
 	edit_->NPages = NPages;
 	if (NPages == 1) {
-		ERecTxtD* er = edit_->RecTxt;
+		ERecTxtD* er = edit_->RecTxt[0];
 		if (er->N == 2) {
 			edit_->HdTxt.clear();
 			edit_->HdTxt.push_back(er->SL[0]);
@@ -490,7 +491,7 @@ void EditReader::NewEditD(FileD* file_d, EditOpt* EO, uint8_t* rec)
 		edit_->NRecs = 1;
 	}
 	else {
-		edit_->NRecs = (edit_->Rows - edit_->NHdTxt) / edit_->RecTxt->N;
+		edit_->NRecs = (edit_->Rows - edit_->NHdTxt) / edit_->RecTxt[0]->N;
 	}
 	edit_->BaseRec = 1;
 	edit_->IRec = 1;


### PR DESCRIPTION
#### PR Classification
This pull request focuses on code cleanup and modernization by replacing manual linked lists with standard library containers and simplifying data structures.

#### PR Summary
The changes streamline data handling and improve code maintainability across several files by removing outdated chained structures and adopting `std::vector` for dynamic data management. Key modifications include:
- Removal of chained structures in `access-structs.h` and simplification of the `ERecTxtD` structure in `rdrun.h`.
- Refactoring of `TMenuBoxP::ExecItem` in `wwmenu.cpp` for better readability and handling of specific cases.
- Updates in `DataEditor.cpp` and `EditReader.cpp` to utilize `std::vector` for efficient data management, replacing previous pointer chaining methods.
