### PR TITLE
Chain removed from LockD

### DIFF
--- a/Core/models/Instr.h
+++ b/Core/models/Instr.h
@@ -355,7 +355,7 @@ public:
 	std::vector<Instr*> WDoInstr;
 	std::vector<Instr*> WElseInstr;
 	bool WasElse = false;
-	LockD WLD;
+	std::vector<LockD*> WLD;
 };
 
 class Instr_graph : public Instr

--- a/Core/rdproc.cpp
+++ b/Core/rdproc.cpp
@@ -2803,7 +2803,9 @@ Instr_assign* RdAssign()
 
 Instr* RdWith()
 {
-	Instr* P = nullptr; Instr* p2 = nullptr; PInstrCode Op;
+	Instr* P = nullptr;
+	PInstrCode Op;
+
 	if (g_compiler->IsKeyWord("WINDOW")) {
 		P = new Instr_window(); //GetPInstr(_window, 29);
 		auto iP = (Instr_window*)P;
@@ -2831,10 +2833,12 @@ Instr* RdWith()
 		Op = PInstrCode::_withlocked;
 	label1:
 		P = new Instr_withshared(Op);
-		auto iP = (Instr_withshared*)P;
-		LockD* ld = &iP->WLD;
+		Instr_withshared* iP = (Instr_withshared*)P;
 
 		while (true) {
+			LockD* ld = new LockD();
+			iP->WLD.push_back(ld);
+
 			ld->FD = g_compiler->RdFileName();
 			if (Op == PInstrCode::_withlocked) {
 				g_compiler->Accept('[');
@@ -2855,8 +2859,6 @@ Instr* RdWith()
 			}
 			if (Lexem == ',') {
 				g_compiler->RdLex();
-				ld->Chain = new LockD();
-				ld = ld->Chain;
 				continue;
 			}
 			break;

--- a/Core/rdrun.h
+++ b/Core/rdrun.h
@@ -225,7 +225,6 @@ struct WrLnD
 
 struct LockD
 {
-	LockD* Chain = nullptr;
 	FileD* FD = nullptr;
 	FrmlElem* Frml = nullptr;
 	LockMode Md, OldMd;


### PR DESCRIPTION
#### PR Classification
This pull request implements a significant code refactor for enhanced lock management and code simplification.

#### PR Summary
The pull request introduces a shift from a linked-list to a `std::vector` for managing multiple locks within `Instr_withshared` instances, improving code maintainability and aligning with modern C++ practices.
- Changes in `Instr.h` to support a `std::vector` of `LockD` pointers for the `WLD` member variable.
- Refactor and updates in `rdproc.cpp` for `RdWith()` function to streamline `WINDOW` and `LOCKED` keyword handling.
- Removal of `Chain` member variable from `LockD` structure in `rdrun.h` and adjustments in lock management functions in `runproc.cpp` to utilize the `std::vector`'s iteration capabilities.
